### PR TITLE
Command bar button styles

### DIFF
--- a/CommandBar/CommandBar/ControlManifest.Input.xml
+++ b/CommandBar/CommandBar/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="PowerCAT" constructor="CommandBar" version="0.0.1" display-name-key="CommandBar" description-key="CommandBar_Desc" control-type="virtual">
+  <control namespace="PowerCAT" constructor="CommandBar" version="0.1.0" display-name-key="CommandBar" description-key="CommandBar_Desc" control-type="virtual">
      
     <!-- OnChange Event Properties -->
     <property name="Theme" display-name-key="Theme" of-type="Multiple" usage="input" required="false" />
@@ -26,6 +26,7 @@
       <property-set name="ItemTopDivider" display-name-key="ItemTopDivider" of-type="TwoOptions" usage="bound" required="false" />
       <property-set name="ItemDivider" display-name-key="ItemDivider" of-type="TwoOptions" usage="bound" required="false" />
       <property-set name="ItemParentKey" display-name-key="ParentKey" of-type="SingleLine.Text" usage="bound" required="false" />
+      <property-set name="ItemStyles" display-name-key="ItemStyles" of-type="Multiple" usage="bound" required="false" />
     </data-set>
 
     <resources>

--- a/CommandBar/CommandBar/ManifestConstants.ts
+++ b/CommandBar/CommandBar/ManifestConstants.ts
@@ -18,6 +18,7 @@ export const enum ItemColumns {
     ItemHeader = 'ItemHeader',
     ItemTopDivider = 'ItemTopDivider',
     ItemDivider = 'ItemDivider',
+    ItemStyles = 'ItemStyles',
 }
 
 export const enum InputEvents {

--- a/CommandBar/CommandBar/components/CanvasCommandBar.tsx
+++ b/CommandBar/CommandBar/components/CanvasCommandBar.tsx
@@ -1,11 +1,11 @@
 import {
     IButtonProps,
-    ICommandBarStyles,
     IContextualMenuItem,
     createTheme,
     ThemeProvider,
     IPartialTheme,
     ICommandBar,
+    mergeThemes,
 } from '@fluentui/react';
 import * as React from 'react';
 import { CommandBar as CommandBarCustom } from '../fluentui-fork/CommandBar/CommandBar';
@@ -66,31 +66,48 @@ export const CanvasCommandBar = React.memo((props: CanvasCommandBarProps) => {
         } as React.CSSProperties;
     }, [width, height]);
 
-    const commandBarStyle = React.useMemo(() => {
-        return {
-            root: {
-                height: height,
-                paddingLeft: 0,
-                // background: 'rgba(255, 255, 255,0)',
-                // This is very important for custom pages
-                // since the min-width is set to the size of the component
-                // we override to ensure that the items do not keep trying to shrink
-                // because the width is clamped
-                // See: https://github.com/microsoft/fluentui/issues/12540
-                minWidth: 0,
+    const defaultTheme = React.useMemo(() => {
+        return createTheme({
+            components: {
+                CommandBar: {
+                    styles: {
+                        root: {
+                            height: height,
+                            paddingLeft: 0,
+                            background: 'rgba(255, 255, 255, 0)',
+                            // This is very important for custom pages
+                            // since the min-width is set to the size of the component
+                            // we override to ensure that the items do not keep trying to shrink
+                            // because the width is clamped
+                            // See: https://github.com/microsoft/fluentui/issues/12540
+                            minWidth: 0,
+                        },
+                    },
+                },
+                CommandBarButton: {
+                    styles: {
+                        root: {
+                            background: 'rgba(255, 255, 255, 0)',
+                        },
+                    },
+                },
             },
-        } as ICommandBarStyles;
+        });
     }, [height]);
 
-    const theme = React.useMemo(() => {
+    const userTheme = React.useMemo(() => {
         try {
-            return themeJSON ? createTheme(JSON.parse(themeJSON) as IPartialTheme) : ({} as IPartialTheme);
+            return (themeJSON ? JSON.parse(themeJSON) : {}) as IPartialTheme;
         } catch (ex) {
             /* istanbul ignore next */
             console.error('Cannot parse theme', ex);
             return {} as IPartialTheme;
         }
     }, [themeJSON]);
+
+    const theme = React.useMemo(() => {
+        return userTheme ? mergeThemes(defaultTheme, userTheme) : defaultTheme;
+    }, [defaultTheme, userTheme]);
 
     const rootRef = React.useRef<HTMLDivElement>(null);
     const async = useAsync();
@@ -126,7 +143,6 @@ export const CanvasCommandBar = React.memo((props: CanvasCommandBarProps) => {
                     componentRef={commandBarRef}
                     className={'PowerCATCommandBar'}
                     tabIndex={tabIndex}
-                    styles={commandBarStyle}
                     items={commandBarItems.rootItems}
                     overflowItems={commandBarItems.overflowItems}
                     overflowButtonProps={overflowProps}

--- a/CommandBar/CommandBar/components/CanvasCommandBar.tsx
+++ b/CommandBar/CommandBar/components/CanvasCommandBar.tsx
@@ -71,7 +71,7 @@ export const CanvasCommandBar = React.memo((props: CanvasCommandBarProps) => {
             root: {
                 height: height,
                 paddingLeft: 0,
-                background: 'rgba(255, 255, 255,0)',
+                // background: 'rgba(255, 255, 255,0)',
                 // This is very important for custom pages
                 // since the min-width is set to the size of the component
                 // we override to ensure that the items do not keep trying to shrink
@@ -84,10 +84,11 @@ export const CanvasCommandBar = React.memo((props: CanvasCommandBarProps) => {
 
     const theme = React.useMemo(() => {
         try {
-            return themeJSON ? createTheme(JSON.parse(themeJSON) as IPartialTheme) : undefined;
+            return themeJSON ? createTheme(JSON.parse(themeJSON) as IPartialTheme) : ({} as IPartialTheme);
         } catch (ex) {
             /* istanbul ignore next */
             console.error('Cannot parse theme', ex);
+            return {} as IPartialTheme;
         }
     }, [themeJSON]);
 

--- a/CommandBar/CommandBar/components/Component.types.ts
+++ b/CommandBar/CommandBar/components/Component.types.ts
@@ -18,6 +18,7 @@ export interface CanvasCommandItem {
     isHeader?: boolean;
     divider?: boolean;
     topDivider?: boolean;
+    stylesJSON?: string;
 }
 
 export interface CanvasCommandBarProps {

--- a/CommandBar/CommandBar/components/DatasetMapping.ts
+++ b/CommandBar/CommandBar/components/DatasetMapping.ts
@@ -1,6 +1,5 @@
 import { CanvasCommandItem } from './Component.types';
 import {
-    concatStyleSets,
     ContextualMenuItemType,
     getColorFromString,
     getShade,

--- a/CommandBar/CommandBar/components/DatasetMapping.ts
+++ b/CommandBar/CommandBar/components/DatasetMapping.ts
@@ -59,19 +59,11 @@ function getDummyAction(key: string): CanvasCommandItem {
 }
 
 function getButtonStyles(stylesJSON?: string): IButtonStyles {
-    const defaultButtonStyles = {
-        root: {
-            background: 'rgba(255, 255, 255,0)',
-        },
-    } as IButtonStyles;
-
     try {
-        return stylesJSON
-            ? concatStyleSets(defaultButtonStyles, JSON.parse(stylesJSON) as IButtonStyles)
-            : defaultButtonStyles;
+        return (stylesJSON ? JSON.parse(stylesJSON) : {}) as IButtonStyles;
     } catch (ex) {
         console.error('Cannot parse command bar item style', ex);
-        return defaultButtonStyles;
+        return {} as IButtonStyles;
     }
 }
 

--- a/CommandBar/CommandBar/components/DatasetMapping.ts
+++ b/CommandBar/CommandBar/components/DatasetMapping.ts
@@ -1,5 +1,6 @@
 import { CanvasCommandItem } from './Component.types';
 import {
+    concatStyleSets,
     ContextualMenuItemType,
     getColorFromString,
     getShade,
@@ -42,6 +43,7 @@ export function getMenuItemsFromDataset(dataset: ComponentFramework.PropertyType
             isHeader: (record.getValue(ItemColumns.ItemHeader) as boolean) ?? undefined,
             topDivider: (record.getValue(ItemColumns.ItemTopDivider) as boolean) ?? undefined,
             divider: (record.getValue(ItemColumns.ItemDivider) as boolean) ?? undefined,
+            stylesJSON: (record.getValue(ItemColumns.ItemStyles) as string) ?? undefined,
             data: record,
         } as CanvasCommandItem;
     });
@@ -54,6 +56,23 @@ function getDummyAction(key: string): CanvasCommandItem {
         name: 'Item ' + key,
         iconName: 'Unknown',
     } as CanvasCommandItem;
+}
+
+function getButtonStyles(stylesJSON?: string): IButtonStyles {
+    const defaultButtonStyles = {
+        root: {
+            background: 'rgba(255, 255, 255,0)',
+        },
+    } as IButtonStyles;
+
+    try {
+        return stylesJSON
+            ? concatStyleSets(defaultButtonStyles, JSON.parse(stylesJSON) as IButtonStyles)
+            : defaultButtonStyles;
+    } catch (ex) {
+        console.error('Cannot parse command bar item style', ex);
+        return defaultButtonStyles;
+    }
 }
 
 export function getCommandsWithChildren(
@@ -80,11 +99,7 @@ export function getCommandBarItemProps(
             return getCommandBarItemProps(items, i, disabled, onClick);
         });
 
-    const buttonStyles = {
-        root: {
-            background: 'rgba(255, 255, 255,0)',
-        },
-    } as IButtonStyles;
+    const buttonStyles = getButtonStyles(item.stylesJSON);
 
     const iconProps =
         item.iconName &&

--- a/CommandBar/README.md
+++ b/CommandBar/README.md
@@ -26,6 +26,7 @@ The control accepts the following properties:
   - **ItemTopDivider** - Render a divider at the top of the section.
   - **ItemDivider** - Render the item as a section divider - or if the item is a header (`ItemHeader` = true), then controls whether to render a divider at the bottom of the section.
   - **ItemParentKey** - Render the option as child item of another option.
+  - **ItemStyles** - Button styles to apply to this item (see [Button Styles](https://developer.microsoft.com/en-us/fluentui#/controls/web/button#IButtonStyles)).
 
 
 ### Style Properties

--- a/CommandBar/package-lock.json
+++ b/CommandBar/package-lock.json
@@ -1974,6 +1974,20 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -2505,9 +2519,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2631,6 +2645,38 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
@@ -4460,6 +4506,14 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -8608,6 +8662,31 @@
         "pcf-scripts": "bin/pcf-scripts.js"
       }
     },
+    "node_modules/pcf-scripts/node_modules/ts-node": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
+      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
+      }
+    },
     "node_modules/pcf-start": {
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/pcf-start/-/pcf-start-1.14.2.tgz",
@@ -10524,28 +10603,73 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
-      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
+        "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "bin": {
         "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
         "ts-node-script": "dist/bin-script.js",
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
       },
-      "engines": {
-        "node": ">=6.0.0"
-      },
       "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
         "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/tslib": {
@@ -10759,6 +10883,14 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
@@ -12557,6 +12689,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -12992,9 +13135,9 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -13096,6 +13239,38 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "@types/babel__core": {
       "version": "7.1.19",
@@ -14557,6 +14732,14 @@
         "object-assign": "^4",
         "vary": "^1"
       }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -17712,6 +17895,21 @@
         "webpack-merge": "^5.8.0",
         "xml2js": "^0.4.19",
         "yargs": "^16.2.0"
+      },
+      "dependencies": {
+        "ts-node": {
+          "version": "8.10.2",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
+          "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+          "dev": true,
+          "requires": {
+            "arg": "^4.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.17",
+            "yn": "3.1.1"
+          }
+        }
       }
     },
     "pcf-start": {
@@ -19181,16 +19379,44 @@
       }
     },
     "ts-node": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
-      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
+        "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
       }
     },
     "tslib": {
@@ -19341,6 +19567,14 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "v8-to-istanbul": {
       "version": "8.1.1",


### PR DESCRIPTION
Added ItemStyles property to Items dataset to allow for JSON styles to be applied to individual command buttons
Moved default styles to use component styles within a default theme (allows makers to override background colors and other default properties)
Fixed issue where null or invalid theme JSON would prevent the default PowerApps theme from applying.