### PR TITLE
Subway Nav Component: Added ability to set individual nodes to any Fluent UI icon and color based on user input

### DIFF
--- a/SubwayNav/README.md
+++ b/SubwayNav/README.md
@@ -17,8 +17,9 @@ The control accepts the following properties:
 - **Items** - The action items to render
   - **ItemKey** - The key to use to indicate which item/step is selected. The keys must be unique.
   - **ItemLabel** - Label for the step
-  - **ItemState** - Specifying the state of the step. Here is the list of State available. Current|NotStarted|Completed|Unsaved|ViewedNotCompleted|Error|CurrentWithSubSteps|Skipped|WizardComplete
-
+  - **ItemState** - Specifying the state of the step. Here is the list of State available. Current|NotStarted|Completed|Unsaved|ViewedNotCompleted|Error|CurrentWithSubSteps|Skipped|WizardComplete|Custom
+  - **ItemIcon** - Will not do anything if ItemState isn't set to Custom. If ItemState is set to Custom, you can input the string value of any FluentUI Icon and it will show up. If the ItemIcon name is invalid, blank or doesn't match any FluentUI Icon's, then it will be set to same Icon as when ItemState is equal to Current. 
+  - **ItemColor** - Will not do anything if ItemState isn't set to Custom. If ItemState is set to Custom, you can input most hexadecimal color codes and that will change the color of the Icon. If the input to this column is invalid, it will default to black. If the input to this column is blank, it will be set to the same color as when ItemState is equal to Current. 
 - **SubwayNav state** - To mark the overall state of SubwayNav to Complete or Error.
 
 ### Style Properties
@@ -142,3 +143,17 @@ Set(varThemeBlueJSON,"{""palette"":{
 ```
 
 The Theme JSON string is passed to the component property, whilst the varTheme can be used to style other standard components such as buttons using the individual colors.
+
+
+
+### Example using Custom Item State
+
+Example of input collection value for Items property
+
+```PowerFx
+Table({ItemKey:"1",ItemLabel:"Step 1",ItemState:"Current"},
+{ItemKey:"2",ItemLabel:"Step 2",ItemState:"Custom", ItemIcon:"Admin",ItemColor: "teal"},
+{ItemKey:"3",ItemLabel:"Step 3",ItemState:"Custom",ItemIcon:"AddTo",ItemColor: "#EE82EE"})
+```
+
+You can use either the names of colors or the colors hexadecimal value. However, color hexadecimal value is recommended. If the color name isn't basic, it most likely won't work. 

--- a/SubwayNav/SubwayNav/ControlManifest.Input.xml
+++ b/SubwayNav/SubwayNav/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="PowerCAT" constructor="SubwayNav" version="1.0.25" display-name-key="SubwayNav" description-key="SubwayNav_Desc" control-type="virtual">
+  <control namespace="PowerCAT" constructor="SubwayNavTesting4" version="1.0.26" display-name-key="SubwayNavTesting4" description-key="SubwayNav_Desc" control-type="virtual">
     <!-- Style Properties -->
     <property name="Theme" display-name-key="Theme" of-type="Multiple" usage="input" required="false" />
     <property name="AccessibilityLabel" display-name-key="AccessibilityLabel" of-type="SingleLine.Text" usage="input" required="false" />
@@ -24,6 +24,8 @@
       <property-set name="ItemState" display-name-key="Item State" of-type="SingleLine.Text" usage="bound" required="true" />
       <property-set name="ItemDisabled" display-name-key="Item Disabled" of-type="TwoOptions" usage="bound" required="false" />
       <property-set name="ItemVisuallyDisabled" display-name-key="Item Visually Disabled" of-type="TwoOptions" usage="bound" required="false" />
+      <property-set name="ItemIcon" display-name-key="Item Icon" of-type="SingleLine.Text" usage="bound" required="false" />
+	    <property-set name="ItemColor" display-name-key="Item Color" of-type="SingleLine.Text" usage="bound" required="false" />
     </data-set>
     <property name="Steps" display-name-key="Steps" of-type="Object" usage="output"/>
     <property name="StepsSchema" display-name-key="StepsSchema" of-type="SingleLine.Text" usage="bound" hidden="true"/>

--- a/SubwayNav/SubwayNav/ControlManifest.Input.xml
+++ b/SubwayNav/SubwayNav/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="PowerCAT" constructor="SubwayNavTesting4" version="1.0.26" display-name-key="SubwayNavTesting4" description-key="SubwayNav_Desc" control-type="virtual">
+  <control namespace="PowerCAT" constructor="SubwayNav" version="1.0.26" display-name-key="SubwayNav" description-key="SubwayNav_Desc" control-type="virtual">
     <!-- Style Properties -->
     <property name="Theme" display-name-key="Theme" of-type="Multiple" usage="input" required="false" />
     <property name="AccessibilityLabel" display-name-key="AccessibilityLabel" of-type="SingleLine.Text" usage="input" required="false" />

--- a/SubwayNav/SubwayNav/ManifestConstants.ts
+++ b/SubwayNav/SubwayNav/ManifestConstants.ts
@@ -8,6 +8,8 @@ export const enum ItemColumns {
     State = 'ItemState',
     Disabled = 'ItemDisabled',
     VisuallyDisabled = 'ItemVisuallyDisabled',
+    ItemIcon = 'ItemIcon',
+    ItemColor = 'ItemColor',
     ParentKey = 'ParentItemKey',
 }
 

--- a/SubwayNav/SubwayNav/_test_/__snapshots__/datasetmapping.test.ts.snap
+++ b/SubwayNav/SubwayNav/_test_/__snapshots__/datasetmapping.test.ts.snap
@@ -128,5 +128,27 @@ Array [
     "state": "Unsaved",
     "visuallyDisabled": undefined,
   },
+  Object {
+        "data": MockEntityRecord {
+          "getNamedReference": [MockFunction],
+          "id": "8",
+          "values": Object {
+            "ItemKey": "Item 8",
+            "ItemLabel": "item8",
+            "ItemState": "Custom",
+            "ItemIcon": 'AddTo',
+            "ItemColor": '#EE82EE',
+          },
+        },
+        "disabled": undefined,
+        "id": "8",
+        "key": "Item 8",
+        "label": "item8",
+        "parentId": undefined,
+        "state": "Custom",
+        "visuallyDisabled": undefined,
+        "ItemIcon": 'AddTo',
+        "ItemColor": '#EE82EE',
+      },
 ]
 `;

--- a/SubwayNav/SubwayNav/_test_/__snapshots__/subwaynav-lifecycle.test.ts.snap
+++ b/SubwayNav/SubwayNav/_test_/__snapshots__/subwaynav-lifecycle.test.ts.snap
@@ -134,6 +134,28 @@ exports[`SubwayNav renders 1`] = `
         "state": "Unsaved",
         "visuallyDisabled": undefined,
       },
+      Object {
+        "data": MockEntityRecord {
+          "getNamedReference": [MockFunction],
+          "id": "8",
+          "values": Object {
+            "ItemKey": "Item 8",
+            "ItemLabel": "item8",
+            "ItemState": "Custom",
+            "ItemIcon": 'AddTo',
+            "ItemColor": '#EE82EE',
+          },
+        },
+        "disabled": undefined,
+        "id": "8",
+        "key": "Item 8",
+        "label": "item8",
+        "parentId": undefined,
+        "state": "Custom",
+        "visuallyDisabled": undefined,
+        "ItemIcon": 'AddTo',
+        "ItemColor": '#EE82EE',
+      },
     ]
   }
   onSelected={[Function]}

--- a/SubwayNav/SubwayNav/_test_/datasetmapping.test.ts
+++ b/SubwayNav/SubwayNav/_test_/datasetmapping.test.ts
@@ -42,6 +42,20 @@ describe('DatasetMapping', () => {
                 [ItemColumns.Label]: 'item4',
                 [ItemColumns.State]: 'Unsaved',
             }),
+            new MockEntityRecord('8', {
+                [ItemColumns.Key]: 'Item 8',
+                [ItemColumns.Label]: 'item8',
+                [ItemColumns.State]: 'Custom',
+                [ItemColumns.ItemIcon]: 'AddFriend',
+                [ItemColumns.ItemColor]: '#C8A2C8',
+            }),
+            new MockEntityRecord('9', {
+                [ItemColumns.Key]: 'Item 9',
+                [ItemColumns.Label]: 'item8',
+                [ItemColumns.State]: 'Custom',
+                [ItemColumns.ItemIcon]: 'AddTo',
+                [ItemColumns.ItemColor]: '#EE82EE',
+            }),
         ];
 
         const actions = getItemsFromDataset(new MockDataSet(items));

--- a/SubwayNav/SubwayNav/_test_/subwaynav-lifecycle.test.ts
+++ b/SubwayNav/SubwayNav/_test_/subwaynav-lifecycle.test.ts
@@ -138,6 +138,20 @@ function createComponent() {
             [ItemColumns.Label]: 'item4',
             [ItemColumns.State]: 'Unsaved',
         }),
+        new MockEntityRecord('8', {
+            [ItemColumns.Key]: 'Item 8',
+            [ItemColumns.Label]: 'item8',
+            [ItemColumns.State]: 'Custom',
+            [ItemColumns.ItemIcon]: 'AddFriend',
+            [ItemColumns.ItemColor]: '#C8A2C8',
+        }),
+        new MockEntityRecord('9', {
+            [ItemColumns.Key]: 'Item 9',
+            [ItemColumns.Label]: 'item8',
+            [ItemColumns.State]: 'Custom',
+            [ItemColumns.ItemIcon]: 'AddTo',
+            [ItemColumns.ItemColor]: '#EE82EE',
+        }),
     ]);
     context.parameters.Theme.raw = JSON.stringify({
         palette: {

--- a/SubwayNav/SubwayNav/components/CanvasSubwayNav.tsx
+++ b/SubwayNav/SubwayNav/components/CanvasSubwayNav.tsx
@@ -27,6 +27,7 @@ const ariaLabelStrings = {
     Skipped: 'Skipped',
     Error: 'Error',
     WizardComplete: 'Wizard Complete',
+    Custom: 'Custom',
 };
 
 export const CanvasSubwayNav = React.memo((props: ISubNavProps): React.ReactElement => {
@@ -114,6 +115,8 @@ export const CanvasSubwayNav = React.memo((props: ISubNavProps): React.ReactElem
                             onClickStep,
                             index: 10,
                             isVisuallyDisabled: item.visuallyDisabled ?? false,
+                            itemIcon: item.itemIcon,
+                            itemColor: item.itemColor,
                         };
                     });
                 return {
@@ -130,6 +133,8 @@ export const CanvasSubwayNav = React.memo((props: ISubNavProps): React.ReactElem
                     onClickStep,
                     index: 10,
                     isVisuallyDisabled: group.visuallyDisabled ?? false,
+                    itemIcon: group.itemIcon,
+                    itemColor: group.itemColor,
                 };
             }) as unknown as ISubwayNavNodeProps[];
         return allSteps;

--- a/SubwayNav/SubwayNav/components/DatasetMapping.ts
+++ b/SubwayNav/SubwayNav/components/DatasetMapping.ts
@@ -24,6 +24,8 @@ export function getItemsFromDataset(dataset: ComponentFramework.PropertyTypes.Da
             disabled: record.getValue(ItemColumns.Disabled),
             parentId: record.getValue(ItemColumns.ParentKey),
             visuallyDisabled: record.getValue(ItemColumns.VisuallyDisabled),
+            itemIcon: record.getValue(ItemColumns.ItemIcon),
+            itemColor: record.getValue(ItemColumns.ItemColor),
             data: record,
         } as ISubNavItem;
     });
@@ -42,6 +44,8 @@ export function getDatasetfromItems(steps: ISubwayNavNodeProps[]): ICustomSubway
                         ItemDisabled: subStep.disabled,
                         ParentItemKey: subStep.parentId,
                         ItemVisuallyDisabled: subStep.isVisuallyDisabled,
+                        ItemIcon: subStep.itemIcon,
+                        ItemColor: subStep.itemColor,
                     } as ICustomSubwayNavProps;
                 }),
             );
@@ -53,6 +57,8 @@ export function getDatasetfromItems(steps: ISubwayNavNodeProps[]): ICustomSubway
             ItemDisabled: step.disabled,
             ParentItemKey: step.parentId,
             ItemVisuallyDisabled: step.isVisuallyDisabled,
+            ItemIcon: step.itemIcon,
+            ItemColor: step.itemColor,
         } as ICustomSubwayNavProps;
     });
     return [...parentstepDateSet, ...stepDataSet];
@@ -65,6 +71,8 @@ function getDummyAction(id: string): ISubNavItem {
         key: id,
         parentId: id === '5' ? '2' : undefined,
         state: id === '1' ? 'Current' : 'Not Started',
+        itemIcon: '',
+        itemColor: '',
     } as ISubNavItem;
 }
 
@@ -88,6 +96,8 @@ export function getSubwayNavNodeState(state: string): SubwayNavNodeState {
             return SubwayNavNodeState.CurrentWithSubSteps;
         case 'WizardComplete':
             return SubwayNavNodeState.WizardComplete;
+        case 'Custom':
+            return SubwayNavNodeState.Custom;
         default:
             return SubwayNavNodeState.NotStarted;
     }

--- a/SubwayNav/SubwayNav/components/StepSchema.ts
+++ b/SubwayNav/SubwayNav/components/StepSchema.ts
@@ -17,6 +17,8 @@ const stepDetails = {
         ItemDisabled: { type: 'boolean' },
         ItemVisuallyDisabled: { type: 'boolean' },
         ParentItemKey: { type: 'string' },
+        ItemIcon: { type: 'string' },
+        ItemColor: { type: 'string' },
     },
 };
 

--- a/SubwayNav/SubwayNav/components/components.types.ts
+++ b/SubwayNav/SubwayNav/components/components.types.ts
@@ -11,6 +11,8 @@ export interface ISubNavItem {
     disabled?: boolean;
     data: any;
     visuallyDisabled?: boolean;
+    itemIcon: string;
+    itemColor: string;
 }
 
 export interface ICustomSubwayNavProps {
@@ -20,6 +22,8 @@ export interface ICustomSubwayNavProps {
     ItemDisabled?: boolean;
     ParentItemKey?: string;
     ItemVisuallyDisabled?: boolean;
+    ItemIcon: string;
+    ItemColor: string;
 }
 
 export interface ISubNavProps {

--- a/SubwayNav/SubwayNav/index.ts
+++ b/SubwayNav/SubwayNav/index.ts
@@ -8,7 +8,7 @@ import { getItemsFromDataset, getDatasetfromItems } from './components/DatasetMa
 import { ISubwayNavNodeProps } from './utilities/subway-nav/subway-node.types';
 import { ContextEx } from './ContextExtended';
 
-export class SubwayNavTesting4 implements ComponentFramework.ReactControl<IInputs, IOutputs> {
+export class SubwayNav implements ComponentFramework.ReactControl<IInputs, IOutputs> {
     notifyOutputChanged: () => void;
     context: ComponentFramework.Context<IInputs>;
     inputEvent?: string | null;

--- a/SubwayNav/SubwayNav/index.ts
+++ b/SubwayNav/SubwayNav/index.ts
@@ -8,7 +8,7 @@ import { getItemsFromDataset, getDatasetfromItems } from './components/DatasetMa
 import { ISubwayNavNodeProps } from './utilities/subway-nav/subway-node.types';
 import { ContextEx } from './ContextExtended';
 
-export class SubwayNav implements ComponentFramework.ReactControl<IInputs, IOutputs> {
+export class SubwayNavTesting4 implements ComponentFramework.ReactControl<IInputs, IOutputs> {
     notifyOutputChanged: () => void;
     context: ComponentFramework.Context<IInputs>;
     inputEvent?: string | null;

--- a/SubwayNav/SubwayNav/utilities/subway-nav/subway-node.types.ts
+++ b/SubwayNav/SubwayNav/utilities/subway-nav/subway-node.types.ts
@@ -142,6 +142,7 @@ export enum SubwayNavNodeState {
     Skipped = 'Skipped',
     Error = 'Error',
     WizardComplete = 'WizardComplete',
+    Custom = 'Custom',
 }
 
 /**

--- a/SubwayNav/SubwayNav/utilities/subway-nav/wizard.types.ts
+++ b/SubwayNav/SubwayNav/utilities/subway-nav/wizard.types.ts
@@ -8,4 +8,5 @@ export enum SubwayNavNodeState {
     Skipped = 'Skipped',
     Error = 'Error',
     WizardComplete = 'WizardComplete',
+    Custom = 'Custom',
 }

--- a/SubwayNav/SubwayNav/utilities/subway-node/subway-node.base.tsx
+++ b/SubwayNav/SubwayNav/utilities/subway-node/subway-node.base.tsx
@@ -28,6 +28,8 @@ export class SubwayNodeBase extends React.Component<ISubwayNavNodeProps> {
             disabled = false,
             isVisuallyDisabled = false,
             state,
+            itemIcon,
+            itemColor,
             subSteps,
             index,
             rootAs,
@@ -36,7 +38,8 @@ export class SubwayNodeBase extends React.Component<ISubwayNavNodeProps> {
             onRenderStepIcon = this._onRenderStepIcon,
         } = this.props;
 
-        const iconRecord: IIconRecord | undefined = getIcon(getIconMap(isSubStep ?? false)[state]);
+        const iconMap = getIcon(getIconMap(isSubStep ?? false, itemIcon)[state]);
+        const iconRecord: IIconRecord | undefined = iconMap || getIcon(getIconMap(isSubStep ?? false, "")[state]);
 
         const buttonProps = getNativeProps<React.ButtonHTMLAttributes<HTMLButtonElement>>(this.props, buttonProperties);
 
@@ -45,6 +48,8 @@ export class SubwayNodeBase extends React.Component<ISubwayNavNodeProps> {
             disabled: disabled,
             isVisuallyDisabled: disabled && isVisuallyDisabled,
             state,
+            itemIcon,
+            itemColor,
             iconRecord: iconRecord!,
             hasSubSteps: subSteps ? subSteps.length > 0 : false,
             index: index!,

--- a/SubwayNav/SubwayNav/utilities/subway-node/subway-node.styles.ts
+++ b/SubwayNav/SubwayNav/utilities/subway-node/subway-node.styles.ts
@@ -16,7 +16,7 @@ export const itemSpacing = 27;
 export const largeSubwayNavIconSize = 16;
 export const smallSubwayNavIconSize = 8;
 
-export const getIconMap = (isSubStep: boolean): SubwayNavStateMap => {
+export const getIconMap = (isSubStep: boolean, Icon: string): SubwayNavStateMap => {
     return isSubStep
         ? {
               Completed: IconNames.StatusCircleCheckMark,
@@ -28,6 +28,7 @@ export const getIconMap = (isSubStep: boolean): SubwayNavStateMap => {
               Unsaved: IconNames.FullCircleMask,
               ViewedNotCompleted: IconNames.FullCircleMask,
               WizardComplete: IconNames.StatusCircleCheckMark,
+              Custom: !Icon ? IconNames.FullCircleMask : Icon,
           }
         : {
               Completed: IconNames.CompletedSolid,
@@ -39,10 +40,11 @@ export const getIconMap = (isSubStep: boolean): SubwayNavStateMap => {
               Unsaved: IconNames.FullCircleMask,
               ViewedNotCompleted: IconNames.FullCircleMask,
               WizardComplete: IconNames.CompletedSolid,
+              Custom: !Icon ? IconNames.FullCircleMask : Icon,
           };
 };
 
-export const getIconColorMap = (isSubStep: boolean, theme: IM365Theme): IconColorMap => {
+export const getIconColorMap = (isSubStep: boolean, theme: IM365Theme, prefferedColor: string): IconColorMap => {
     return isSubStep
         ? {
               Completed: throwOnUndefinedColor(theme.semanticColors.stepCompleted, 'stepCompleted', 'SubwayNode'),
@@ -58,6 +60,8 @@ export const getIconColorMap = (isSubStep: boolean, theme: IM365Theme): IconColo
                   'allStepsComplete',
                   'SubwayNode',
               ),
+              Custom: !prefferedColor ? throwOnUndefinedColor(theme.semanticColors.stepCurrent, 'stepCurrent', 'SubwayNode') : 
+              throwOnUndefinedColor(prefferedColor, 'ItemColor', 'UserInput'),
           }
         : {
               Completed: throwOnUndefinedColor(theme.semanticColors.stepCompleted, 'stepCompleted', 'SubwayNode'),
@@ -77,6 +81,8 @@ export const getIconColorMap = (isSubStep: boolean, theme: IM365Theme): IconColo
                   'allStepsComplete',
                   'SubwayNode',
               ),
+              Custom: !prefferedColor ? throwOnUndefinedColor(theme.semanticColors.stepCurrent, 'stepCurrent', 'SubwayNode') : 
+              throwOnUndefinedColor(prefferedColor, 'ItemColor', 'UserInput'),
           };
 };
 
@@ -91,11 +97,12 @@ export const getIconRingColorMap = (theme: IM365Theme): IconRingColorMap => {
         Unsaved: theme.palette.accent,
         ViewedNotCompleted: 'transparent',
         WizardComplete: 'transparent',
+        Custom: 'transparent',
     };
 };
 
 export const getSubwayNodeStyles = (props: ISubwayNavNodeStyleProps): ISubwayNavNodeStyles => {
-    const { disabled, isVisuallyDisabled, isSubStep, iconRecord, state, theme } = props;
+    const { disabled, isVisuallyDisabled, isSubStep, iconRecord, state, itemColor, theme } = props;
     const options: IGetFocusStylesOptions = {
         inset: undefined,
         position: undefined,
@@ -105,6 +112,7 @@ export const getSubwayNodeStyles = (props: ISubwayNavNodeStyleProps): ISubwayNav
         borderColor: 'transparent',
         outlineColor: undefined,
     };
+    const iconColorMap = getIconColorMap(isSubStep, theme, itemColor)[state];
     const useSelectedStyle: boolean =
         state === SubwayNavNodeState.Current || state === SubwayNavNodeState.CurrentWithSubSteps;
 
@@ -156,7 +164,7 @@ export const getSubwayNodeStyles = (props: ISubwayNavNodeStyleProps): ISubwayNav
         icon: [
             iconRecord?.subset.className,
             {
-                fill: visualDisabledBehavior(getIconColorMap(isSubStep, theme)[state]),
+                fill: visualDisabledBehavior(iconColorMap || getIconColorMap(isSubStep, theme, "")[state]),
                 fontSize: iconSize,
             },
         ],

--- a/SubwayNav/SubwayNav/utilities/subway-node/subway-node.types.ts
+++ b/SubwayNav/SubwayNav/utilities/subway-node/subway-node.types.ts
@@ -36,6 +36,16 @@ export interface ISubwayNavNodeProps extends React.AllHTMLAttributes<HTMLButtonE
     state: SubwayNavNodeState;
 
     /**
+     *  If state is equal to "Custom", this prop will be used to determine the Icon type (Fluent UI)
+     */
+    itemIcon: string;
+
+    /**
+     *  If state is equal to "Custom", this prop will be used to determine the Icon's color
+     */
+    itemColor: string;
+
+    /**
      * AriaLabel of the icon
      */
     iconAriaLabel?: string;
@@ -142,6 +152,7 @@ export enum SubwayNavNodeState {
     Skipped = 'Skipped',
     Error = 'Error',
     WizardComplete = 'WizardComplete',
+    Custom = 'Custom',
 }
 
 /**
@@ -217,6 +228,16 @@ export interface ISubwayNavNodeStyleProps {
      *  State of the step
      */
     state: SubwayNavNodeState;
+
+    /**
+     *  If state is equal to "Custom", this prop will be used to determine the Icon type (Fluent UI)
+     */
+    itemIcon: string;
+
+    /**
+     *  If state is equal to "Custom", this prop will be used to determine the Icon's color
+     */
+    itemColor: string;
 
     /**
      * Icon record prop used in style merging


### PR DESCRIPTION
Enhanced the subway nav component by adding the ability to set individual nodes to any Fluent UI icon and color based on user input. It’s backward compatible, so it won’t disrupt older versions of the subway nav component.

1) Added the "Custom" item state. Set the item state of a node to "Custom" when you want to use an icon/icon color combination that isn't available.
2) Added two new columns to the Items property:
**ItemIcon**: Will not do anything if ItemState isn't set to Custom. If ItemState is set to Custom, you can input the string value of any FluentUI Icon and it will show up. If the ItemIcon name is invalid, blank or doesn't match any FluentUI Icon, then it will be set to same Icon as when ItemState is equal to Current.

**ItemColor**:  Will not do anything if ItemState isn't set to Custom. If ItemState is set to Custom, you can input most hexadecimal color codes and that will change the color of the Icon. If the input to this column is invalid, it will default to black. If the input to this column is blank, it will be set to the same color as when ItemState is equal to Current.
 
![image](https://github.com/microsoft/powercat-code-components/assets/146996651/adde1a35-975e-4c77-91ac-a631bdc47a04)
